### PR TITLE
And Virtual Konsole Control

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -4,33 +4,9 @@ module.exports = (instance) => {
 			name: 'Get Function List',
 			options: [],
 			callback: () => {
-				this.log('debug', instance.sendCommand(`QLC+API|getFunctionsList`))
+				instance.log('debug', instance.sendCommand(`QLC+API|getFunctionsList`))
 			},
 		},
-		// getFunctionStatus: {
-		// 	name: 'Get Function Status based on a ID',
-		// 	options: [
-		// 		{
-		// 			type: 'dropdown',
-		// 			label: 'Function',
-		// 			id: 'functionID',
-		// 			default: 0,
-		// 			choices: instance.qlcplusObj.functions,
-		// 		},
-		// 	],
-		// 	callback: async (event) => {
-		// 		//Find the matching function:
-		// 		const targetFunction = instance.qlcplusObj.functions.find((f) => f.id === event.options.functionID)
-		// 		if (targetFunction) {
-		// 			targetFunction.status = instance.convertDataToJavascriptObject(
-		// 				await instance.sendCommand(`QLC+API|getFunctionStatus|${event.options.functionID}`)
-		// 			)[0].id
-		// 			instance.setVariableValues({ ['Function'+targetFunction.id]: targetFunction.status })
-		// 			instance.checkFeedbacks('functionState')
-		// 		}
-		// 		instance.log('debug', `Function ${event.options.functionID} is ${targetFunction.status}`)
-		// 	},
-		// },
 		setFunctionStatus: {
 			name: 'Set Function Status',
 			options: [
@@ -54,9 +30,7 @@ module.exports = (instance) => {
 			],
 			callback: (event) => {
 				instance.sendCommand(`QLC+API|setFunctionStatus|${event.options.functionID}|${event.options.status}`)
-				// Build delay???
 				instance.sendCommand(`QLC+API|getFunctionStatus|${event.options.functionID}`)
-				// Build delay???
 				instance.checkFeedbacks('functionState')
 			},
 		},
@@ -88,6 +62,225 @@ module.exports = (instance) => {
 			],
 			callback: (event) => {
 				instance.sendCommand(`${event.options.widgetID}|${event.options.value}`)
+			},
+		},
+		// Virtual Console Slider Control
+		setSliderValue: {
+			name: 'Set Virtual Console Slider Value',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Slider Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Select a Slider widget from Virtual Console',
+				},
+				{
+					type: 'number',
+					label: 'Value (0-255)',
+					id: 'value',
+					default: 128,
+					min: 0,
+					max: 255,
+				},
+			],
+			callback: (event) => {
+				instance.sendCommand(`${event.options.widgetID}|${event.options.value}`)
+			},
+		},
+		// Virtual Console Button Control
+		pressButton: {
+			name: 'Press Virtual Console Button',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Button Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Select a Button widget from Virtual Console',
+				},
+				{
+					type: 'dropdown',
+					label: 'Action',
+					id: 'action',
+					choices: [
+						{ id: '255', label: 'Press' },
+						{ id: '0', label: 'Release' },
+					],
+					default: '255',
+				},
+			],
+			callback: (event) => {
+				instance.sendCommand(`${event.options.widgetID}|${event.options.action}`)
+			},
+		},
+		// Virtual Console Button Toggle
+		toggleButton: {
+			name: 'Toggle Virtual Console Button',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Button Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Toggle a Button widget on Virtual Console',
+				},
+			],
+			callback: async (event) => {
+				// Press
+				await instance.sendCommand(`${event.options.widgetID}|255`)
+				// Small delay
+				setTimeout(() => {
+					// Release
+					instance.sendCommand(`${event.options.widgetID}|0`)
+				}, 100)
+			},
+		},
+		// Virtual Console Cue List Control
+		setCueListStep: {
+			name: 'Set Cue List Step',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Cue List Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Select a Cue List widget',
+				},
+				{
+					type: 'number',
+					label: 'Step Number',
+					id: 'step',
+					default: 0,
+					min: 0,
+				},
+			],
+			callback: (event) => {
+				instance.sendCommand(`${event.options.widgetID}|${event.options.step}`)
+			},
+		},
+		// Virtual Console Frame Page Control
+		setFramePage: {
+			name: 'Set Frame Page',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Frame Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Select a Frame widget with multiple pages',
+				},
+				{
+					type: 'number',
+					label: 'Page Number',
+					id: 'page',
+					default: 0,
+					min: 0,
+				},
+			],
+			callback: (event) => {
+				instance.sendCommand(`${event.options.widgetID}|${event.options.page}`)
+			},
+		},
+		// Virtual Console XY Pad Control
+		setXYPadPosition: {
+			name: 'Set XY Pad Position',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'XY Pad Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Select an XY Pad widget',
+				},
+				{
+					type: 'number',
+					label: 'X Position (0-255)',
+					id: 'xPos',
+					default: 128,
+					min: 0,
+					max: 255,
+				},
+				{
+					type: 'number',
+					label: 'Y Position (0-255)',
+					id: 'yPos',
+					default: 128,
+					min: 0,
+					max: 255,
+				},
+			],
+			callback: (event) => {
+				// XY Pad requires two commands
+				instance.sendCommand(`${event.options.widgetID}|${event.options.xPos}|${event.options.yPos}`)
+			},
+		},
+		// Virtual Console Speed Dial Control
+		setSpeedDialValue: {
+			name: 'Set Speed Dial Value',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Speed Dial Widget',
+					id: 'widgetID',
+					default: 0,
+					choices: instance.qlcplusObj.widgets,
+					tooltip: 'Select a Speed Dial widget',
+				},
+				{
+					type: 'number',
+					label: 'Speed (ms)',
+					id: 'speed',
+					default: 1000,
+					min: 0,
+					max: 999999,
+				},
+			],
+			callback: (event) => {
+				instance.sendCommand(`${event.options.widgetID}|${event.options.speed}`)
+			},
+		},
+		// Blackout Control
+		setBlackout: {
+			name: 'Set Blackout',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Blackout State',
+					id: 'state',
+					choices: [
+						{ id: '1', label: 'On' },
+						{ id: '0', label: 'Off' },
+					],
+					default: '1',
+				},
+			],
+			callback: (event) => {
+				instance.sendCommand(`QLC+API|setBlackout|${event.options.state}`)
+			},
+		},
+		// Load Project
+		loadProject: {
+			name: 'Load Project',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Project Path',
+					id: 'path',
+					default: '',
+					tooltip: 'Full path to the QLC+ project file',
+				},
+			],
+			callback: (event) => {
+				if (event.options.path) {
+					instance.sendCommand(`QLC+API|loadProject|${event.options.path}`)
+				}
 			},
 		},
 	})


### PR DESCRIPTION
This pull request adds several new actions for controlling various Virtual Console widgets and system functions in the QLC+ API integration, and makes minor cleanup to existing code. The most significant changes are the addition of new widget control actions, which greatly expand the functionality available to users.

### New Virtual Console Widget Control Actions

* Added actions to control Virtual Console widgets: sliders (`setSliderValue`), buttons (`pressButton`, `toggleButton`), cue lists (`setCueListStep`), frames (`setFramePage`), XY pads (`setXYPadPosition`), and speed dials (`setSpeedDialValue`). These actions allow users to interact programmatically with different widget types.
* Added blackout control (`setBlackout`) and project loading (`loadProject`) actions for broader system management.

### Code Cleanup and Consistency

* Updated the callback for the 'Get Function List' action to use `instance.log` instead of `this.log` for consistency.
* Removed commented-out code for the 'Get Function Status' action, cleaning up the codebase.
* Removed unnecessary comments regarding delays in the 'Set Function Status' callback for clarity.