### PR TITLE
QLC+ v4: improve function/widget labeling, sorting, and add boolean feedback

### DIFF
--- a/feedbacks.js
+++ b/feedbacks.js
@@ -1,11 +1,19 @@
 const { combineRgb } = require('@companion-module/base')
 const feedbacksSettings = require('./constants').feedbacksSettings
 
+function getFunctionChoices(instance) {
+	return Array.isArray(instance?.qlcplusObj?.functions) ? instance.qlcplusObj.functions : []
+}
+
+function findFunctionById(instance, id) {
+	const funcs = getFunctionChoices(instance)
+	return funcs.find((f) => String(f.id) === String(id))
+}
 module.exports = async (instance) => {
 	instance.setFeedbackDefinitions({
 		functionState: {
 			name: 'State of function',
-			type: 'boolean',
+			type: 'advanced',
 			label: 'Function State',
 			defaultStyle: {
 				bgcolor: combineRgb(255, 0, 0),
@@ -21,8 +29,8 @@ module.exports = async (instance) => {
 				},
 			],
 			callback: (feedback) => {
-				if (!instance.qlcplusObj.functions) return false
-				const targetFunction = instance.qlcplusObj.functions.find((f) => f.id === feedback.options.functionID)
+				if (!instance.qlcplusObj.functions) return {}
+				const targetFunction = findFunctionById(instance, feedback.options.functionID)
 				if (targetFunction) {
 					if (targetFunction.status === 'Running') {
 						return {
@@ -38,5 +46,55 @@ module.exports = async (instance) => {
 				}
 			},
 		},
+
+		functionRunning: {
+			name: 'Function is Running',
+			type: 'boolean',
+			defaultStyle: {
+				// conservative default; user can adjust later
+				bgcolor: combineRgb(0, 128, 0),
+			},
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Function ID source',
+					id: 'idSource',
+					default: 'dropdown',
+					choices: [
+						{ id: 'dropdown', label: 'Select from list' },
+						{ id: 'manual', label: 'Manual (supports variables)' },
+					],
+				},
+				{
+					type: 'dropdown',
+					label: 'Function',
+					id: 'functionID',
+					default: getFunctionChoices(instance)?.[0]?.id ?? 0,
+					choices: getFunctionChoices(instance),
+					isVisible: (opts) => (opts?.idSource ?? 'dropdown') === 'dropdown',
+				},
+				{
+					type: 'textinput',
+					label: 'Function ID (manual)',
+					id: 'functionIDManual',
+					default: '',
+					useVariables: true,
+					isVisible: (opts) => (opts?.idSource ?? 'dropdown') === 'manual',
+				},
+			],
+			callback: async (feedback, context) => {
+				let id
+
+				if ((feedback.options.idSource ?? 'dropdown') === 'manual') {
+					id = await context.parseVariablesInString(feedback.options.functionIDManual || '')
+				} else {
+					id = feedback.options.functionID
+				}
+
+				const fn = findFunctionById(instance, id)
+				return fn?.status === 'Running'
+			},
+		},
+
 	})
 }

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -5,7 +5,7 @@ module.exports = async (instance) => {
 	instance.setFeedbackDefinitions({
 		functionState: {
 			name: 'State of function',
-			type: 'advanced',
+			type: 'boolean',
 			label: 'Function State',
 			defaultStyle: {
 				bgcolor: combineRgb(255, 0, 0),

--- a/main.js
+++ b/main.js
@@ -1,4 +1,6 @@
 const { InstanceBase, Regex, runEntrypoint, InstanceStatus } = require('@companion-module/base')
+const pkg = require('./package.json')
+const MODULE_BUILD = pkg.version
 const UpgradeScripts = require('./upgrades')
 const UpdateActions = require('./actions')
 const UpdateFeedbacks = require('./feedbacks')
@@ -13,9 +15,13 @@ class ModuleInstance extends InstanceBase {
 	}
 
 	async init(config) {
+		this.log('info', `QLC+ module loaded, build: ${MODULE_BUILD}`)
 		this.qlcplusObj = { widgets: [], functions: [] }
 		this.latestFunctionID = 0
 		this.isDestroyed = false
+
+		// Cache widget types across reconnects to avoid re-querying everything
+		this.widgetTypeById = {}
 
 		await this.configUpdated(config)
 	}
@@ -95,14 +101,167 @@ class ModuleInstance extends InstanceBase {
 		}
 	}
 
+	parseQlcTypeReply(resp, expectedCommand) {
+		const parts = resp?.toString?.().split('|') || []
+		if (parts.length < 3) return ''
+
+		// Verify the response is for the expected command
+		// Response typically begins: QLC+API|<command>|...
+		if (expectedCommand && parts[1] !== expectedCommand) return ''
+
+		const candidate = parts[parts.length - 1] || ''
+
+		// Reject numeric tokens (prevents caching widget id as "type")
+		if (/^\d+$/.test(candidate)) return ''
+
+		return candidate
+	}
+
+	formatFunctionLabel(fn, countsByType) {
+		const raw = (fn?.labelRaw ?? fn?.label ?? '').trim()
+		const type = fn?.type || ''
+
+		// Base label: include type prefix when known
+		const base = type ? `${type}: ${raw}` : raw
+
+		// If we can't evaluate duplicates, just return base
+		if (!countsByType || !type || !raw) return base
+
+		// Duplicates only within the SAME type → append ID
+		const key = `${type}|${raw}`
+		if ((countsByType[key] || 0) > 1) {
+			return `${base} [${fn.id}]`
+		}
+
+		return base
+	}
+
+	formatWidgetLabel(w, countsByType) {
+		const raw = (w?.labelRaw ?? '').trim()
+		const type = w?.widgetType || 'Widget'
+
+		// Blank caption → always show ID
+		if (!raw) {
+			return `${type} #${w.id}`
+		}
+
+		const base = this.formatPrefixedLabel(type, raw)
+
+		// Duplicates only within the SAME type → append ID
+		const key = `${type}|${raw}`
+		if ((countsByType?.[key] || 0) > 1) {
+			return `${base} [${w.id}]`
+		}
+
+		return base
+	}
+
 	async getBaseData() {
+
 		// Get Functions List
 		this.qlcplusObj.functions = this.convertDataToJavascriptObject(await this.sendCommand('QLC+API|getFunctionsList'))
+
+		// Enrich functions with type (no final label formatting yet)
+		for (const fn of this.qlcplusObj.functions) {
+			try {
+				const resp = await this.sendCommand(`QLC+API|getFunctionType|${fn.id}`)
+				fn.type = this.parseQlcTypeReply(resp, 'getFunctionType')
+			} catch (e) {
+				fn.type = fn.type || ''
+			}
+		}
+
+		// Count duplicates by (type, raw name)
+		const functionNameCountsByType = {}
+
+		for (const fn of this.qlcplusObj.functions) {
+			const raw = (fn.labelRaw ?? fn.label ?? '').trim()
+			if (!raw) continue
+
+			const type = fn.type || 'Other'
+			const key = `${type}|${raw}`
+			functionNameCountsByType[key] = (functionNameCountsByType[key] || 0) + 1
+		}
+
+		// Format labels (append [id] only when duplicate within same type)
+		for (const fn of this.qlcplusObj.functions) {
+			fn.label = this.formatFunctionLabel(fn, functionNameCountsByType)
+		}
+
+		// Sort functions by type, then by raw name
+		this.qlcplusObj.functions.sort((a, b) => {
+			// Empty types last
+			const ta = a.type || 'ZZZ'
+			const tb = b.type || 'ZZZ'
+			if (ta !== tb) return ta.localeCompare(tb)
+
+			// Secondary sort by raw name
+			const na = (a.labelRaw ?? a.label ?? '').trim()
+			const nb = (b.labelRaw ?? b.label ?? '').trim()
+			return na.localeCompare(nb)
+		})
+
+		// Get Widgets List
 		this.qlcplusObj.widgets = this.convertDataToJavascriptObject(await this.sendCommand('QLC+API|getWidgetsList'))
+
+		// Enrich widgets with widgetType (no label formatting yet)
+		for (const w of this.qlcplusObj.widgets) {
+			try {
+				const wid = String(w.id)
+
+				let widgetType = this.widgetTypeById[wid]
+				if (widgetType && /^\d+$/.test(widgetType)) widgetType = ''
+
+				if (!widgetType) {
+					const resp = await this.sendCommand(`QLC+API|getWidgetType|${w.id}`)
+					widgetType = this.parseQlcTypeReply(resp, 'getWidgetType')
+					if (widgetType) this.widgetTypeById[wid] = widgetType
+				}
+
+				w.widgetType = widgetType || ''
+			} catch (e) {
+				w.widgetType = w.widgetType || ''
+			}
+		}
+
+		// Count duplicates by (widgetType, caption)
+		const widgetCaptionCountsByType = {}
+
+		for (const w of this.qlcplusObj.widgets) {
+			const raw = (w.labelRaw ?? '').trim()
+			if (!raw) continue
+
+			const type = w.widgetType || 'Widget'
+			const key = `${type}|${raw}`
+
+			widgetCaptionCountsByType[key] = (widgetCaptionCountsByType[key] || 0) + 1
+		}
+
+		// Format labels (smart disambiguation within same type)
+		for (const w of this.qlcplusObj.widgets) {
+			try {
+				w.label = this.formatWidgetLabel(w, widgetCaptionCountsByType)
+			} catch (e) {
+				w.label = w.labelRaw ?? w.label
+			}
+		}
+
+		// Sort widgets by widgetType, then by caption (labelRaw)
+		// Empty types last to avoid weird “unknown” items at the top
+		this.qlcplusObj.widgets.sort((a, b) => {
+			const ta = a.widgetType || 'ZZZ'
+			const tb = b.widgetType || 'ZZZ'
+			if (ta !== tb) return ta.localeCompare(tb)
+
+			const na = a.labelRaw ?? a.label ?? ''
+			const nb = b.labelRaw ?? b.label ?? ''
+			return na.localeCompare(nb)
+		})
+
 		this.updateActions() // export actions
 		this.updateFeedbacks() // export feedbacks
 		this.updateVariableDefinitions() // export variable definitions
-		this.checkFeedbacks('function_state') // check feedbacks
+		this.checkFeedbacks('functionState', 'functionRunning') // check feedbacks
 	}
 
 	convertDataToJavascriptObject(data) {
@@ -112,7 +271,7 @@ class ModuleInstance extends InstanceBase {
 		for (let i = 0; i < dataInArray.slice(2).length; i += 2) {
 			const id = dataInArray.slice(2)[i]
 			const label = dataInArray.slice(2)[i + 1]
-			resultArray.push({ id, label })
+			resultArray.push({ id, label, labelRaw: label })
 		}
 		return resultArray
 	}
@@ -169,7 +328,7 @@ class ModuleInstance extends InstanceBase {
 						if (targetFunction) {
 							targetFunction.status = messageArray[2]
 							this.setVariableValues({ ['Function' + targetFunction.id]: targetFunction.status })
-							this.checkFeedbacks('functionState')
+							this.checkFeedbacks('functionState', 'functionRunning')
 						}
 						break
 


### PR DESCRIPTION
Summary
- Add boolean feedback `functionRunning` to enable user-controlled button styling and trigger usage based on function Running/Stopped state.
- Preserve raw QLC+ names via `labelRaw` and derive deterministic display labels.
- Add robust parsing for QLC+ type replies (use last token; ignore numeric tokens) to tolerate response shape variations across QLC+ v4.
- Enrich functions with type, prefix dropdown labels with function type, and disambiguate duplicate names within the same type by appending `[id]`.
- Enrich widgets with `widgetType`, prefix dropdown labels with widget type, provide stable fallback labels for blank captions (`"<Type> #<id>"`), and disambiguate duplicate captions within the same `widgetType` by appending `[id]`.
- Sort both functions and widgets by type, then by raw name, to group entries consistently in dropdowns.
- Cache widget type lookups across reconnects to reduce repeated `getWidgetType` API calls.
- Keep `functionState` as an advanced feedback and trigger feedback re-evaluation for both `functionState` and `functionRunning` when function status updates are received.

User-visible changes
- A new boolean feedback (`functionRunning`) is available for styling and triggers.
- Function and widget dropdown entries are now type-prefixed and may include IDs when captions are blank or duplicated within the same type.
- Dropdown ordering groups entries by type for easier navigation.
